### PR TITLE
Set globalSettings instead of "workspace" settings

### DIFF
--- a/LSP-ruff.sublime-settings
+++ b/LSP-ruff.sublime-settings
@@ -3,19 +3,25 @@
         "settings": {
             // Custom arguments passed to ruff.
             // See ruff documentation at https://github.com/charliermarsh/ruff/blob/main/README.md#configuration
-            "args": [],
+            // "args": [],
+
             // Sets the tracing level for the extension.
-            "logLevel": "error",
+            // "logLevel": "error",
+
             // Setting to provide custom ruff executables, to try in order.
-            "path": [],
+            // "path": [],
+
             // Path to a Python interpreter to use to run the linter server.
-            "interpreter": [],
+            // "interpreter": [],
+
             // Setting to control when a notification is shown.
-            "showNotification": "off",
+            // "showNotification": "off",
+
             // Whether to register Ruff as capable of handling source.organizeImports actions.
-            "organizeImports": true,
+            // "organizeImports": true,
+
             // Whether to register Ruff as capable of handling source.fixAll actions.
-            "fixAll": true
+            // "fixAll": true
         },
         "globalSettings": {
             // same as settings

--- a/LSP-ruff.sublime-settings
+++ b/LSP-ruff.sublime-settings
@@ -1,30 +1,24 @@
 {
     "initializationOptions": {
         "settings": {
-            // Custom arguments passed to ruff.
-            // See ruff documentation at https://github.com/charliermarsh/ruff/blob/main/README.md#configuration
-            // "args": [],
-
-            // Sets the tracing level for the extension.
-            // "logLevel": "error",
-
-            // Setting to provide custom ruff executables, to try in order.
-            // "path": [],
-
-            // Path to a Python interpreter to use to run the linter server.
-            // "interpreter": [],
-
-            // Setting to control when a notification is shown.
-            // "showNotification": "off",
-
-            // Whether to register Ruff as capable of handling source.organizeImports actions.
-            // "organizeImports": true,
-
-            // Whether to register Ruff as capable of handling source.fixAll actions.
-            // "fixAll": true
+            // same as globalSettings
         },
         "globalSettings": {
-            // same as settings
+            // Sets the tracing level for the extension.
+            "logLevel": "error",
+            // Custom arguments passed to ruff.
+            // See ruff documentation at https://github.com/charliermarsh/ruff/blob/main/README.md#configuration
+            "args": [],
+            // Setting to provide custom ruff executables, to try in order.
+            "path": [],
+            // Path to a Python interpreter to use to run the linter server.
+            "interpreter": [],
+            // Setting to control when a notification is shown.
+            "showNotification": "off",
+            // Whether to register Ruff as capable of handling source.organizeImports actions.
+            "organizeImports": true,
+            // Whether to register Ruff as capable of handling source.fixAll actions.
+            "fixAll": true
         },
     },
     "command": [

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -19,6 +19,13 @@
                 "logLevel": {
                   "type": "string",
                   "default": "error",
+                  "enum": [
+                    "error",
+                    "warn",
+                    "info",
+                    "debug",
+                    "off"
+                  ],
                   "description": "Sets the tracing level for the extension."
                 },
                 "path": {


### PR DESCRIPTION
Looks like we should not be setting default options explicitly as then those will override `globalSettings`. See `rust-lsp` code here: https://github.com/charliermarsh/ruff-lsp/blob/8474ad1092843ffbf4e6d4d3f030588ab902a060/ruff_lsp/server.py#L724-L730

Fixes issue mentioned in #18