### PR TITLE
don't generate locked requirements

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,2 +1,0 @@
-# Use pip-compile from the pip-tools package to generate a "locked" requirements.txt
-ruff-lsp==0.0.35

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,1 @@
-attrs==22.2.0
-cattrs==22.2.0
-lsprotocol==2023.0.0a1
-pygls==1.0.1
-ruff==0.0.274
 ruff-lsp==0.0.35
-typeguard==2.13.3
-typing-extensions==4.5.0


### PR DESCRIPTION
We've been generating a lock file to fix #8 but apparently it can cause another issue (#27).

Since #8 doesn't seem to be an issue anymore, we'll revert to only pinning `rust-lsp` itself.

Fixes #27