### PR TITLE
fix: replace "globalSettings" with "settings"

### DIFF
--- a/LSP-ruff.sublime-settings
+++ b/LSP-ruff.sublime-settings
@@ -25,8 +25,6 @@
             "lint.preview": null,
             // Sets the tracing level for the extension.
             "logLevel": "error",
-            // Setting to control when a notification is shown.
-            "showNotification": "off",
             // Whether to register Ruff as capable of handling source.organizeImports actions.
             "organizeImports": true,
             // Whether to register Ruff as capable of handling source.fixAll actions.

--- a/LSP-ruff.sublime-settings
+++ b/LSP-ruff.sublime-settings
@@ -1,10 +1,7 @@
 {
     "initializationOptions": {
-        "settings": {
-            // same as globalSettings
-        },
         // See https://docs.astral.sh/ruff/editors/settings/
-        "globalSettings": {
+        "settings": {
             // Path to a ruff.toml or pyproject.toml file to use for configuration.
             // By default, Ruff will discover configuration for each project from the filesystem, mirroring the behavior of the Ruff CLI.
             "configuration": null,

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -128,9 +128,6 @@
                   "properties": {
                     "settings": {
                       "$ref": "sublime://settings/LSP-ruff#/definitions/LspRuffSettings",
-                    },
-                    "globalSettings": {
-                      "$ref": "sublime://settings/LSP-ruff#/definitions/LspRuffSettings",
                     }
                   }
                 }

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -98,7 +98,8 @@
                 "showNotification": {
                   "type": "string",
                   "default": "off",
-                  "description": "Setting to control when a notification is shown."
+                  "description": "Setting to control when a notification is shown.",
+                  "deprecationMessage": "This option only works in VS Code."
                 },
                 "organizeImports": {
                   "type": "boolean",


### PR DESCRIPTION
"globalSettings" seems to be no longer working for `ruff`. It works for `ruff-lsp`.

Also remove/deprecate the "showNotification" setting as per https://github.com/sublimelsp/LSP-ruff/issues/66#issuecomment-2244785831.

Resolves https://github.com/sublimelsp/LSP-ruff/issues/66