### PR TITLE
add venv bin path to PATH

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
+
 from LSP.plugin import ClientConfig
-from lsp_utils import GenericClientHandler, UvVenvManager
+from lsp_utils import GenericClientHandler
+from lsp_utils import UvVenvManager
 from pathlib import Path
 from typing import final
 from typing_extensions import override
@@ -44,6 +46,13 @@ class RuffLsp(GenericClientHandler):
                 'server_path': str(cls.uv_venv_manager.venv_bin_path / 'ruff')
             })
         return variables
+
+    @classmethod
+    @override
+    def get_additional_paths(cls) -> list[str]:
+        if uv_venv_manager := cls.uv_venv_manager:
+            return [str(uv_venv_manager.venv_bin_path)]
+        return []
 
 
 def plugin_loaded() -> None:


### PR DESCRIPTION
When converting from `PipClientHandler` I haven't realized that it had logic that added venv path to the PATH of the server process. Since we had it there, I'm also proposing it here in case it's needed. I've added it in https://github.com/sublimelsp/lsp_utils/pull/67 but I don't see references to any specific python issue it was solving even if it seems like the right thing to do.

That said, if user overrides `command` to use another server instance then we'd likely not want to add venv to the path. This seemed wrong with `PipClientHandler` also so I should probably address it here.