### PR TITLE
refactor: replace deprecated initializationOptions with initialization_options

### DIFF
--- a/LSP-ruff.sublime-settings
+++ b/LSP-ruff.sublime-settings
@@ -1,6 +1,6 @@
 {
     // See https://docs.astral.sh/ruff/editors/settings/
-    "initializationOptions": {
+    "initialization_options": {
         // Configuration overrides for Ruff. See the documentation (https://docs.astral.sh/ruff/editors/settings/#configuration) for more details.
         "settings.configuration": null,
         // The strategy to use when resolving settings across editor and the filesystem. By default, editor configuration is prioritized over ruff.toml and pyproject.toml files.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ There are multiple ways to configure the package and the language server.
 		"settings": {
 			"LSP": {
 				"LSP-ruff": {
-					"initializationOptions": {
+					"initialization_options": {
 						// Put your settings here
 					}
 				}

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -170,7 +170,7 @@
             },
             "PluginConfig": {
               "properties": {
-                "initializationOptions": {
+                "initialization_options": {
                   "$ref": "sublime://settings/LSP-ruff#/definitions/LspRuffSettings",
                 }
               }


### PR DESCRIPTION
In https://github.com/sublimelsp/LSP/releases/tag/4070-2.9.0 `config.init_options`
and `initializationOptions` in settings were deprecated.

(This is a semi-automatically created PR that might not
have been tested manually.)
