### PR TITLE
refactor: add ruff rules for sorting imports

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
+
 from LSP.plugin import ClientConfig
-from lsp_utils import GenericClientHandler, UvVenvManager
+from lsp_utils import GenericClientHandler
+from lsp_utils import UvVenvManager
 from pathlib import Path
 from typing import final
 from typing_extensions import override

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,18 @@ select = [
     "E",
     "F",
     "W",
+    "F401",
+    "I",
 ]
+preview = true
+
+[tool.ruff.lint.isort]
+case-sensitive = false
+force-single-line = true
+from-first = true
+no-sections = true
+order-by-type = false
+required-imports = ["from __future__ import annotations"]
 
 [tool.pyright]
 pythonVersion = "3.8"


### PR DESCRIPTION
This is a semi-automatically created PR that adds ruff configuration for imports formatting.

It matches configuration included in the LSP package with the intention of consolidating import style across all LSP packages.

If you have strong preference to a different style, please keep the configuration but update it to your liking so that anyone working on the package does not have to guess the correct style to use. See [ruff isort settings](https://docs.astral.sh/ruff/settings/#lintisort).

(Since this PR was created semi-automatically, it might require some changes before being considered ready.)